### PR TITLE
Coerce undefined to string

### DIFF
--- a/src/ractive-codemirror.js
+++ b/src/ractive-codemirror.js
@@ -52,7 +52,7 @@
 					if( updating )
 						return
 					updating = true
-					editor.setValue( val )
+					editor.setValue( val ||'')
 					updating = false
 					return
 				}


### PR DESCRIPTION
If `val` is `undefined`, CodeMirror breaks.  This happened to me when my ractive code was dynamically creating and removing codemirror components.  Coercing undefined to a string seemed to resolve the problem.